### PR TITLE
Add reason tracking and check‑in message

### DIFF
--- a/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
+++ b/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
@@ -17,13 +17,14 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
   end
 
   def create
-    params.require(%i[user_id date points])
+    params.require(%i[user_id date points reason])
     params.permit(:description)
 
     event = DiscourseGamification::GamificationScoreEvent.record!(
       user_id: params[:user_id],
       date: params[:date],
       points: params[:points],
+      reason: params[:reason],
       description: params[:description],
     )
 
@@ -31,13 +32,13 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
   end
 
   def update
-    params.require(%i[id points])
+    params.require(%i[id points reason])
     params.permit(:description)
 
     event = DiscourseGamification::GamificationScoreEvent.find(params[:id])
     raise Discourse::NotFound unless event
 
-    if event.update(points: params[:points], description: params[:description] || event.description)
+    if event.update(points: params[:points], reason: params[:reason], description: params[:description] || event.description)
       render json: success_json
     else
       render_json_error(event)

--- a/app/controllers/discourse_gamification/check_ins_controller.rb
+++ b/app/controllers/discourse_gamification/check_ins_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DiscourseGamification::CheckInsController < ApplicationController
+  requires_plugin DiscourseGamification::PLUGIN_NAME
+  before_action :ensure_logged_in
+
+  def create
+    today = Date.current
+    reason = SiteSetting.day_visited_score_reason
+
+    existing = DiscourseGamification::GamificationScoreEvent.find_by(
+      user_id: current_user.id,
+      date: today,
+      reason: reason,
+    )
+
+    if existing
+      render json: { points_awarded: false, points: 0 }
+    else
+      event = DiscourseGamification::GamificationScoreEvent.record!(
+        user_id: current_user.id,
+        date: today,
+        points: SiteSetting.day_visited_score_value,
+        reason: reason,
+      )
+
+      render json: { points_awarded: true, points: event.points }
+    end
+  end
+end

--- a/app/models/discourse_gamification/gamification_score_event.rb
+++ b/app/models/discourse_gamification/gamification_score_event.rb
@@ -10,8 +10,10 @@ module ::DiscourseGamification
     after_commit :update_score, on: :update
     after_commit :decrement_score, on: :destroy
 
-    def self.record!(user_id:, points:, date: Date.today, description: nil)
-      create!(user_id: user_id, points: points, date: date, description: description)
+    validates :reason, presence: true
+
+    def self.record!(user_id:, points:, date: Date.today, reason:, description: nil)
+      create!(user_id: user_id, points: points, date: date, reason: reason, description: description)
     end
 
     private
@@ -42,6 +44,7 @@ end
 #  date        :date             not null
 #  points      :integer          not null
 #  description :text
+#  reason      :string           default("")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/serializers/admin_gamification_score_event_serializer.rb
+++ b/app/serializers/admin_gamification_score_event_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AdminGamificationScoreEventSerializer < ApplicationSerializer
-  attributes :id, :user_id, :date, :points, :description, :created_at, :updated_at
+  attributes :id, :user_id, :date, :points, :reason, :description, :created_at, :updated_at
 end

--- a/assets/javascripts/initializers/check-in.js
+++ b/assets/javascripts/initializers/check-in.js
@@ -1,0 +1,19 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { ajax } from "discourse/lib/ajax";
+import I18n from "I18n";
+
+export default {
+  name: "discourse-gamification-check-in",
+  initialize() {
+    withPluginApi("1.2.0", (api) => {
+      if (!api.getCurrentUser()) {
+        return;
+      }
+      ajax("/gamification/check-in.json").then((result) => {
+        if (result.points_awarded) {
+          api.addFlash(I18n.t("gamification.check_in_awarded", { points: result.points }), "success");
+        }
+      });
+    });
+  },
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -60,6 +60,7 @@ en:
       recalculate: "Recalculate scores"
       recalculating: "Recalculating scores..."
       completed: "Done! The scores have been successfully recalculated."
+      check_in_awarded: "You received %{points} points for checking in today"
       update_scores_help: "Update all scores for all leaderboards from"
       update_range:
         last_10_days: "Last 10 days"

--- a/config/locales/client.ko.yml
+++ b/config/locales/client.ko.yml
@@ -37,3 +37,4 @@ ko:
       custom_range_from: "보내는사람"
       admin:
         name: "이름"
+      check_in_awarded: "출석체크로 %{points} 포인트가 부여되었습니다"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,3 +42,7 @@ Discourse::Application.routes.draw do
         "discourse_gamification/admin_gamification_score_event#update",
       :constraints => StaffConstraint.new
 end
+
+Discourse::Application.routes.draw do
+  post "/gamification/check-in" => "discourse_gamification/check_ins#create"
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,8 @@ discourse_gamification:
     default: 10
   day_visited_score_value:
     default: 1
+  day_visited_score_reason:
+    default: "day_visited"
   reaction_received_score_value:
     default: 1
   reaction_given_score_value:

--- a/db/migrate/20250103120000_add_reason_to_gamification_score_events.rb
+++ b/db/migrate/20250103120000_add_reason_to_gamification_score_events.rb
@@ -1,0 +1,5 @@
+class AddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :gamification_score_events, :reason, :string, null: false, default: ""
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,7 @@ register_asset "stylesheets/common/leaderboard-info-modal.scss"
 register_asset "stylesheets/common/leaderboard-minimal.scss"
 register_asset "stylesheets/common/leaderboard-admin.scss"
 register_asset "stylesheets/common/gamification-score.scss"
+register_asset "javascripts/initializers/check-in.js"
 
 register_svg_icon "crown"
 register_svg_icon "award"
@@ -128,7 +129,7 @@ after_initialize do
         user_id: user.id,
         date: post.created_at.to_date,
         points: DiscourseGamification::PostCreated.score_multiplier,
-        description: "post_created"
+        reason: "post_created"
       )
     end
   end
@@ -141,7 +142,7 @@ after_initialize do
         user_id: post_action.user_id,
         date: post_action.created_at.to_date,
         points: DiscourseGamification::LikeGiven.score_multiplier,
-        description: "like_given"
+        reason: "like_given"
       )
     end
 
@@ -150,7 +151,7 @@ after_initialize do
         user_id: post_action.post.user_id,
         date: post_action.created_at.to_date,
         points: DiscourseGamification::LikeReceived.score_multiplier,
-        description: "like_received"
+        reason: "like_received"
       )
     end
   end
@@ -163,7 +164,7 @@ after_initialize do
         user_id: post_action.user_id,
         date: post_action.created_at.to_date,
         points: -DiscourseGamification::LikeGiven.score_multiplier,
-        description: "like_removed"
+        reason: "like_removed"
       )
     end
 
@@ -172,7 +173,7 @@ after_initialize do
         user_id: post_action.post.user_id,
         date: post_action.created_at.to_date,
         points: -DiscourseGamification::LikeReceived.score_multiplier,
-        description: "like_removed"
+        reason: "like_removed"
       )
     end
   end

--- a/spec/requests/admin_gamification_score_event_controller_spec.rb
+++ b/spec/requests/admin_gamification_score_event_controller_spec.rb
@@ -14,18 +14,21 @@ RSpec.describe DiscourseGamification::AdminGamificationScoreEventController do
       user_id: current_user.id,
       date: Date.today,
       points: 7,
+      reason: "post_created",
     )
 
     score_events << DiscourseGamification::GamificationScoreEvent.create!(
       user_id: current_user.id,
       date: Date.yesterday,
       points: 17,
+      reason: "post_created",
     )
 
     score_events << DiscourseGamification::GamificationScoreEvent.create!(
       user_id: another_user.id,
       date: Date.yesterday,
       points: 27,
+      reason: "post_created",
     )
 
     DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
@@ -73,6 +76,7 @@ RSpec.describe DiscourseGamification::AdminGamificationScoreEventController do
              points: 10,
              user_id: another_user.id,
              date: Date.today,
+             reason: "post_created",
            }
       expect(response.status).to eq(200)
 
@@ -89,6 +93,7 @@ RSpec.describe DiscourseGamification::AdminGamificationScoreEventController do
             points: 13,
             user_id: another_user.id,
             date: Date.yesterday,
+            reason: "post_created",
           }
       expect(response.status).to eq(200)
 

--- a/spec/requests/check_ins_controller_spec.rb
+++ b/spec/requests/check_ins_controller_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe DiscourseGamification::CheckInsController do
+  fab!(:user)
+
+  before { SiteSetting.discourse_gamification_enabled = true }
+
+  it "awards points once per day" do
+    sign_in(user)
+
+    post "/gamification/check-in.json"
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["points_awarded"]).to eq(true)
+
+    post "/gamification/check-in.json"
+    expect(response.parsed_body["points_awarded"]).to eq(false)
+  end
+end


### PR DESCRIPTION
## Summary
- track reasons for score events
- add daily check-in endpoint and message
- show message when points are awarded for daily check-in

## Testing
- `bundle exec rake db:migrate` *(fails: missing gems)*
- `bundle exec rake` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_6861f0e7c4bc832c948fbae371a2a0bc