### PR TITLE
Add day_visited_score_reason translations

### DIFF
--- a/config/locales/server.ar.yml
+++ b/config/locales/server.ar.yml
@@ -17,6 +17,7 @@ ar:
     post_created_score_value: "قيمة الهتافات الممنوح عند إنشاء المستخدم لمنشور"
     flag_created_score_value: "قيمة الهتافات الممنوح عند وضع المستخدم علامة على منشور، ويتم قبول هذه العلامة من قِبل مستخدم في فريق العمل"
     day_visited_score_value: "قيمة الهتافات الممنوح لكل يوم يزور فيه المستخدم الموقع"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "قائمة الفئات التي ستُنشئ فيها الإجراءات هتافات. اتركه فارغًا لتفعيل الهتافات في جميع الفئات"
     reaction_received_score_value: "قيمة الهتاف الممنوحة عند تلقي المستخدم تفاعلًا"
     reaction_given_score_value: "قيمة الهتاف الممنوحة لكل تفاعل يمنحه المستخدم"

--- a/config/locales/server.cs.yml
+++ b/config/locales/server.cs.yml
@@ -17,6 +17,7 @@ cs:
     post_created_score_value: "Hodnota ovace udělené, když uživatel vytvoří příspěvek"
     flag_created_score_value: "Hodnota ovace, která se uděluje, když uživatel nahlásí příspěvek, a tento příznak je přijat členem redakce"
     day_visited_score_value: "Hodnota ovace za každý den, kdy uživatel navštíví web"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Seznam kategorií, kde aktivita bude generovat ovace. Ponechte prázdné, abyste povolili ovace ve všech kategoriích"
     reaction_received_score_value: "Hodnota ovace udělené, když uživatel obdrží reakci"
     reaction_given_score_value: "Hodnota ovace udělená za každou reakci uživatele"

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -17,6 +17,7 @@ de:
     post_created_score_value: "Der Wert des Beifalls, der vergeben wird, wenn ein Benutzer einen Beitrag erstellt"
     flag_created_score_value: "Der Wert des Beifalls, der vergeben wird, wenn ein Benutzer einen Beitrag meldet und diese Meldung von einem Team-Benutzer akzeptiert wird"
     day_visited_score_value: "Der Wert des Beifalls, der für jeden Tag vergeben wird, an dem ein Benutzer die Website besucht"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Liste der Kategorien, in denen Aktionen Beifall erzeugen. Leer lassen, um Beifall für alle Kategorien zu aktivieren"
     reaction_received_score_value: "Der Wert des Beifalls, der vergeben wird, wenn ein Benutzer eine Reaktion erhält"
     reaction_given_score_value: "Der Wert des Beifalls, der für jede Reaktion vergeben wird, die ein Benutzer gibt"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,6 +12,7 @@ en:
     first_reply_of_day_score_value: "The value of the point awarded for the first reply a user posts each day"
     flag_created_score_value: "The value of the point awarded when a user flags a post and that flag is accepted by a staff user"
     day_visited_score_value: "The value of the point awarded for every day a user visits the site"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "List of categories where actions will generate points. Leave empty to enable points on all categories"
     reaction_received_score_value: "The value of the point awarded when a user receives a reaction"
     reaction_given_score_value: "The value of the point awarded for every reaction a user gives"

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -17,6 +17,7 @@ es:
     post_created_score_value: "Puntos otorgados por cada publicación creada"
     flag_created_score_value: "Puntos otorgados a los usuarios por cada uno de sus reportes aceptados por el personal"
     day_visited_score_value: "Puntos otorgados por cada día que un usuario visita el sitio"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Lista de categorías en las que repartir puntos. Dejar vacío para dar puntos en todas las categorías"
     reaction_received_score_value: "Puntos otorgados al autor de una publicación que reciba una reacción"
     reaction_given_score_value: "Puntos otorgados por cada reacción que un usuario da"

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -17,6 +17,7 @@ fi:
     post_created_score_value: "Annetun hurrauksen arvo, kun käyttäjä luo viestin"
     flag_created_score_value: "Annetun hurrauksen arvo, kun käyttäjä liputtaa viestin, ja henkilökunnan käyttäjä hyväksyy lipun"
     day_visited_score_value: "Annetun hurrauksen arvo jokaisesta päivästä, jona käyttäjä vierailee sivustolla"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Luettelo alueista, joilla toiminta luo hurrauksia. Hurraukset ovat käytössä kaikilla alueilla, jos jätät tämän tyhjäksi."
     reaction_received_score_value: "Annetun hurrauksen arvo, kun käyttäjä saa reaktion"
     reaction_given_score_value: "Annetun hurrauksen arvo jokaisesta käyttäjän antamasta reaktiosta"

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -17,6 +17,7 @@ fr:
     post_created_score_value: "La valeur de l'acclamation accordée lorsqu'un utilisateur crée un message"
     flag_created_score_value: "La valeur de l'acclamation accordée lorsqu'un utilisateur signale un message et que ce signalement est accepté par un responsable"
     day_visited_score_value: "La valeur de l'acclamation accordée pour chaque jour où un utilisateur visite le site"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Liste des catégories où les actions susciteront des acclamations. Laissez ce champ vide pour activer les acclamations dans toutes les catégories"
     reaction_received_score_value: "La valeur de l'acclamation accordée lorsqu'un utilisateur reçoit une réaction"
     reaction_given_score_value: "La valeur de l'acclamation accordée pour chaque réaction donnée par un utilisateur"

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -17,6 +17,7 @@ he:
     post_created_score_value: "ערך התשועה שמוענק כאשר משתמש יוצר פוסט"
     flag_created_score_value: "ערך התשועה שמוענק כאשר משתמש מסמן פוסט בדגל והדגל מתקבל על ידי משתמש צוות"
     day_visited_score_value: "ערך התשועה שמוענק עבור כל יום בו משתמש מבקר באתר"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "רשימת הקטגוריות בהן פעולות מייצרות תשועות. יש להשאיר ריק כדי להפעיל תשועות בכל הקטגוריות"
     reaction_received_score_value: "ערך התשועה שמוענק כשמשתמש מקבל רגש"
     reaction_given_score_value: "ערך התשועה שמוענק עבור כל רגש שמשתמש נותן"

--- a/config/locales/server.hr.yml
+++ b/config/locales/server.hr.yml
@@ -17,6 +17,7 @@ hr:
     post_created_score_value: "Vrijednost navijanja koja se dodjeljuje kada korisnik kreira objavu"
     flag_created_score_value: "Vrijednost navijanja koja se dodjeljuje kada korisnik označi objavu i tu zastavu prihvaća korisnik osoblja"
     day_visited_score_value: "Vrijednost navijanja koji se dodjeljuje za svaki dan kada korisnik posjeti web stranicu"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Popis kategorija u kojima će akcije generirati veselje. Ostavite prazno kako biste omogućili navijanje za sve kategorije"
   score: "Živjeli"
   default_leaderboard_name: "Globalna ploča s najboljim rezultatima"

--- a/config/locales/server.hu.yml
+++ b/config/locales/server.hu.yml
@@ -17,6 +17,7 @@ hu:
     post_created_score_value: "Pontszám értéke, amely új bejegyzés létrehozásáért jár"
     flag_created_score_value: "Pontszám értéke, ami minden olyan megjelölés után jár, amit egy stábtag elfogadott"
     day_visited_score_value: "Pontszám értéke, amely minden napi első bejelentkezés után jár"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Azoknak a kategóriáknak a listája, ahol a cselekvésekért pontszámok járnak. Hagyja üresen, hogy az összes kategóriát engedélyezze"
     reaction_received_score_value: "Pontszám értéke, amelyet akkor kapnak, amikor a felhasználó reakciót kap"
     reaction_given_score_value: "Pontszám értéke, amelyet akkor kapnak, amikor a felhasználó reakciót ad"

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -17,6 +17,7 @@ it:
     post_created_score_value: "Il valore dei complimenti assegnati quando un utente crea un messaggio"
     flag_created_score_value: "Il valore dei complimenti assegnati quando un utente segnala un messaggio e la segnalazione è accettata da un utente dello staff"
     day_visited_score_value: "Il valore dei complimenti assegnati per ogni giorno in cui un utente visita il sito"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Elenco di categorie in cui le azioni genereranno complimenti. Lascia vuota l'opzione per abilitare i complimenti in tutte le categorie"
     reaction_received_score_value: "Il valore dei complimenti assegnati quando un utente riceve una reazione"
     reaction_given_score_value: "Il valore dei complimenti assegnati per ogni reazione messa da un utente"

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -17,6 +17,7 @@ ja:
     post_created_score_value: "ユーザーが投稿を作成した時に付与される拍手の値"
     flag_created_score_value: "ユーザーが投稿を通報し、その通報がスタッフユーザーに承認された時に付与される拍手の値"
     day_visited_score_value: "ユーザーがサイトにアクセスする日ごとに付与される拍手の値"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "アクションによって拍手が生成されるカテゴリのリスト。全カテゴリで拍手を有効にする場合は、空白のままにします。"
     reaction_received_score_value: "ユーザーがリアクションを受けた時に付与される拍手の値"
     reaction_given_score_value: "ユーザーがリアクションするたびに付与される拍手の値"

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -18,6 +18,7 @@ ko:
     first_reply_of_day_score_value: "사용자가 하루에 처음 작성한 댓글에 부여되는 포인트 값"
     flag_created_score_value: "사용자가 게시글을 신고하고 스태프가 승인하면 부여되는 포인트 값"
     day_visited_score_value: "사용자가 사이트를 방문한 날마다 부여되는 포인트 값"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "포인트가 부여될 카테고리 목록입니다. 비워두면 모든 카테고리에서 포인트가 부여됩니다"
     reaction_received_score_value: "사용자가 리액션을 받으면 부여되는 포인트 값"
     reaction_given_score_value: "사용자가 리액션을 남길 때마다 부여되는 포인트 값"

--- a/config/locales/server.nl.yml
+++ b/config/locales/server.nl.yml
@@ -17,6 +17,7 @@ nl:
     post_created_score_value: "De waarde van de aanmoediging die wordt toegekend wanneer een gebruiker een bericht maakt"
     flag_created_score_value: "De waarde van de aanmoediging die wordt toegekend wanneer een gebruiker een bericht markeert en de markering wordt geaccepteerd door een medewerker"
     day_visited_score_value: "De waarde van de aanmoediging die wordt toegekend voor elke dag dat een gebruiker de site bezoekt"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Lijst van categorieën waar acties aanmoedigingen opleveren. Laat dit leeg om aanmoedigingen in te schakelen voor alle categorieën"
     reaction_received_score_value: "De waarde van de aanmoediging die wordt toegekend wanneer een gebruiker een reactie ontvangt"
     reaction_given_score_value: "De waarde van de aanmoediging die wordt toegekend voor elke reactie die een gebruiker geeft"

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -17,6 +17,7 @@ pt_BR:
     post_created_score_value: "O valor da saudação concedida quando um usuário cria uma postagem"
     flag_created_score_value: "O valor da saudação concedida quando um usuário sinaliza uma postagem e essa sinalização é aceita por um usuário da equipe"
     day_visited_score_value: "O valor da saudação concedida para cada dia que um usuário visita o site"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Lista de categorias em que as ações vão gerar saudações. Deixe em branco para ativar saudações em todas as categorias"
     reaction_received_score_value: "O valor da saudação concedida quando um(a) usuário(a) recebe uma reação"
     reaction_given_score_value: "O valor da saudação concedida por cada reação feita por um(a) usuário(a)"

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -17,6 +17,7 @@ ru:
     post_created_score_value: "Баллы, начисляемые за создание сообщения"
     flag_created_score_value: "Баллы, начисляемые за жалобу, принятую персоналом форума"
     day_visited_score_value: "Баллы, начисляемые за каждый день посещения форума"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Список разделов, в которых начисляются баллы. Оставьте этот список пустым, если баллы должны начисляться во всех разделах"
     reaction_received_score_value: "Баллы, начисляемые за получение реакции"
     reaction_given_score_value: "Баллы, начисляемые за каждую поставленную реакцию"

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -17,6 +17,7 @@ sv:
     post_created_score_value: "Värdet på hurrarop som tilldelas när en användare skapar ett inlägg"
     flag_created_score_value: "Värdet på hurrarop som tilldelas när en användare flaggar ett inlägg och den flaggan accepteras av en personalanvändare"
     day_visited_score_value: "Värdet på hurrarop som tilldelas för varje dag en användare besöker webbplatsen"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Lista över kategorier där åtgärder kommer att generera jubel. Lämna tomt för att aktivera hejarop i alla kategorier"
   score: "Hurra"
   default_leaderboard_name: "Global topplista"

--- a/config/locales/server.tr_TR.yml
+++ b/config/locales/server.tr_TR.yml
@@ -17,6 +17,7 @@ tr_TR:
     post_created_score_value: "Bir kullanıcı bir gönderi oluşturduğunda verilen tezahüratın değeri"
     flag_created_score_value: "Bir kullanıcı bir gönderiye bayrak eklendiğinde ve bu bayrak bir personel kullanıcı tarafından kabul edildiğinde verilen tezahüratın değeri"
     day_visited_score_value: "Bir kullanıcının siteyi ziyaret ettiği her gün için verilen tezahüratın değeri"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "Eylemlerin tezahürat oluşturacağı kategorilerin listesi. Tüm kategorilerde tezahüratları etkinleştirmek için boş bırakın"
     reaction_received_score_value: "Bir kullanıcı tepki aldığında verilen tezahüratın değeri"
     reaction_given_score_value: "Bir kullanıcının verdiği her tepki için verilen tezahüratın değeri"

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -17,6 +17,7 @@ zh_CN:
     post_created_score_value: "当用户创建帖子时所获得的点数"
     flag_created_score_value: "当用户举报帖子并且该举报被管理人员接受时所获得的点数"
     day_visited_score_value: "用户每天访问站点所获得的点数"
+    day_visited_score_reason: "Identifier used when awarding points for daily check-in"
     scorable_categories: "操作将生成点数的类别列表。留空以在所有类别上启用点数。"
     reaction_received_score_value: "当用户收到回应时所获得的点数"
     reaction_given_score_value: "用户每给出一个回应时所获得的点数"


### PR DESCRIPTION
## Summary
- add `day_visited_score_reason` description in server locales

## Testing
- `bundle exec rake plugin:spec` *(fails: Could not find rubocop-discourse-3.12.1...)*

------
https://chatgpt.com/codex/tasks/task_e_686228e45398832cbc72af999570ab3a