### PR TITLE
Fix null constraint migration

### DIFF
--- a/db/migrate/20250103120000_add_reason_to_gamification_score_events.rb
+++ b/db/migrate/20250103120000_add_reason_to_gamification_score_events.rb
@@ -2,12 +2,17 @@
 
 class AddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def up
+    # 1. Add the column as nullable with a default empty string
     add_column :gamification_score_events, :reason, :string, default: "", null: true
+
+    # 2. Populate existing rows with the empty string
     execute <<~SQL
       UPDATE gamification_score_events
       SET reason = ''
       WHERE reason IS NULL
     SQL
+
+    # 3. Enforce NOT NULL constraint once the table is backfilled
     change_column_null :gamification_score_events, :reason, false
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,7 +17,6 @@ register_asset "stylesheets/common/leaderboard-info-modal.scss"
 register_asset "stylesheets/common/leaderboard-minimal.scss"
 register_asset "stylesheets/common/leaderboard-admin.scss"
 register_asset "stylesheets/common/gamification-score.scss"
-register_asset "javascripts/initializers/check-in.js"
 
 register_svg_icon "crown"
 register_svg_icon "award"


### PR DESCRIPTION
## Summary
- clarify steps when adding `reason` column
- remove obsolete check-in initializer from plugin

## Testing
- `bundle exec rake plugin:spec` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68622d9ba674832c938dc7f952fb30c2