### PR TITLE
Fix duplicate score rows before indexing

### DIFF
--- a/db/migrate/20250630080000_update_scores_to_cumulative.rb
+++ b/db/migrate/20250630080000_update_scores_to_cumulative.rb
@@ -3,7 +3,34 @@
 class UpdateScoresToCumulative < ActiveRecord::Migration[7.0]
   def up
     remove_index :gamification_scores, [:user_id, :date]
+
+    if column_exists?(:gamification_scores, :created_at)
+      execute <<~SQL
+        DELETE FROM gamification_scores gs
+        USING (
+          SELECT id,
+                 ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC) AS rn
+          FROM gamification_scores
+        ) AS dups
+        WHERE gs.id = dups.id
+          AND dups.rn > 1;
+      SQL
+    else
+      execute <<~SQL
+        DELETE FROM gamification_scores gs
+        USING (
+          SELECT id,
+                 ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY id DESC) AS rn
+          FROM gamification_scores
+        ) AS dups
+        WHERE gs.id = dups.id
+          AND dups.rn > 1;
+      SQL
+    end
+
     add_index :gamification_scores, :user_id, unique: true
+
+    execute "DELETE FROM gamification_scores"
 
     execute <<~SQL
       WITH summed AS (
@@ -11,7 +38,6 @@ class UpdateScoresToCumulative < ActiveRecord::Migration[7.0]
         FROM gamification_scores
         GROUP BY 1
       )
-      DELETE FROM gamification_scores;
       INSERT INTO gamification_scores (user_id, score, date)
       SELECT user_id, score, CURRENT_DATE FROM summed;
     SQL


### PR DESCRIPTION
## Summary
- clean up duplicate gamification score rows before making `user_id` unique
- delete all score rows, then insert back a summed result

## Testing
- `bundle exec rake db:migrate:status` *(fails: missing gems)*


------
https://chatgpt.com/codex/tasks/task_e_68633366f464832c850b29222ddaa2f5