### PR TITLE
Implement points for topics and accepted answers

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
     like_received_score_value: "The value of the point awarded when a user receives a like"
     like_given_score_value: "The value of the point awarded for every like a user gives"
     solution_score_value: "The value of the point awarded when a user's post is marked as a solution"
+    solution_topic_score_value: "The value of the point awarded to a topic author when a reply is accepted"
     user_invited_score_value: "The value of the point awarded when a user has an invite redeemed"
     time_read_score_value: "The value of the point awarded for every hour of time spent reading"
     post_read_score_value: "The value of the point awarded for every one hundred posts a user reads"

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -10,6 +10,7 @@ ko:
     like_received_score_value: "사용자가 좋아요를 받으면 부여되는 포인트 값"
     like_given_score_value: "사용자가 좋아요를 할 때마다 부여되는 포인트 값"
     solution_score_value: "사용자의 게시물이 해결책으로 선택되면 부여되는 포인트 값"
+    solution_topic_score_value: "답변이 채택될 때 게시글 작성자에게 부여되는 포인트 값"
     user_invited_score_value: "초대가 수락될 때 부여되는 포인트 값"
     time_read_score_value: "읽은 시간 한 시간마다 부여되는 포인트 값"
     post_read_score_value: "100개의 게시글을 읽을 때마다 부여되는 포인트 값"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,9 @@ discourse_gamification:
   like_given_score_value:
     default: 1
   solution_score_value:
-    default: 10
+    default: 5
+  solution_topic_score_value:
+    default: 2
   user_invited_score_value:
     default: 10
   time_read_score_value:
@@ -20,7 +22,7 @@ discourse_gamification:
   post_read_score_value:
     default: 1
   topic_created_score_value:
-    default: 5
+    default: 1
 
   score_first_reply_of_day_enabled:
     default: true

--- a/lib/discourse_gamification/scorables/solution_topic.rb
+++ b/lib/discourse_gamification/scorables/solution_topic.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ::DiscourseGamification
+  class SolutionTopic < Scorable
+    def self.enabled?
+      defined?(DiscourseSolved) && SiteSetting.solved_enabled && super
+    end
+
+    def self.score_multiplier
+      SiteSetting.solution_topic_score_value
+    end
+
+    def self.category_filter
+      return "" if scorable_category_list.empty?
+
+      <<~SQL
+        AND topics.category_id IN (#{scorable_category_list})
+      SQL
+    end
+
+    def self.query
+      <<~SQL
+        SELECT
+          topics.user_id AS user_id,
+          date_trunc('day', dsst.updated_at) AS date,
+          COUNT(dsst.topic_id) * #{score_multiplier} AS points
+        FROM
+          discourse_solved_solved_topics dsst
+        INNER JOIN topics
+          ON dsst.topic_id = topics.id
+          #{category_filter}
+        INNER JOIN posts
+          ON posts.id = dsst.answer_post_id
+        WHERE
+          posts.deleted_at IS NULL AND
+          topics.deleted_at IS NULL AND
+          topics.archetype <> 'private_message' AND
+          posts.user_id != topics.user_id AND
+          dsst.updated_at >= :since
+        GROUP BY
+          1, 2
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- award points when a new topic is created
- award points to both the answer author and topic author when a reply is accepted
- add `solution_topic_score_value` site setting with translations
- update defaults for solution and topic created scores
- include new scorable `SolutionTopic`

## Testing
- `bundle exec rake db:migrate` *(fails: missing gems)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865eb7585d8832c9cfb0aeda3ea7eab