### PR TITLE
Add instant event scoring with category filters

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -23,6 +23,10 @@ en:
     chat_reaction_given_score_value: "The value of the point awarded for every reaction a user gives to a chat message"
     chat_message_created_score_value: "The value of the point awarded for every message a user sends in a chat"
     score_ranking_strategy: "Leaderboard position ranking strategy"
+    instant_event_category_filters: "Instant event category filters"
+    post_created_event_categories: "Categories where creating a post will award points immediately. Leave empty to apply to all"
+    accepted_solution_event_categories: "Categories where having a reply accepted will award points immediately. Leave empty to apply to all"
+    accepted_solution_topic_event_categories: "Categories where marking a reply as accepted will award points to the topic author. Leave empty to apply to all"
   score: "Points"
   default_leaderboard_name: "Global Leaderboard"
   rate_limiter:

--- a/config/locales/server.ko.yml
+++ b/config/locales/server.ko.yml
@@ -29,6 +29,10 @@ ko:
     chat_reaction_given_score_value: "사용자가 채팅 메시지에 리액션을 남길 때마다 부여되는 포인트 값"
     chat_message_created_score_value: "사용자가 채팅 메시지를 보낼 때마다 부여되는 포인트 값"
     score_ranking_strategy: "리더보드 순위 계산 방식"
+    instant_event_category_filters: "즉시 이벤트 카테고리 필터"
+    post_created_event_categories: "게시글 작성 시 즉시 포인트가 부여될 카테고리 목록입니다. 비워두면 모든 카테고리에 적용됩니다"
+    accepted_solution_event_categories: "게시글이 채택될 때 즉시 포인트가 부여될 카테고리 목록입니다. 비워두면 모든 카테고리에 적용됩니다"
+    accepted_solution_topic_event_categories: "답변을 채택한 사용자에게 포인트를 부여할 카테고리 목록입니다. 비워두면 모든 카테고리에 적용됩니다"
   score: "포인트"
   default_leaderboard_name: "전 세계 리더보드"
   rate_limiter:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,3 +60,16 @@ discourse_gamification:
       - dense_rank
       - rank
       - row_number
+
+  ## Instant event category filters
+  instant_event_category_filters:
+    type: header
+  post_created_event_categories:
+    type: category_list
+    default: ""
+  accepted_solution_event_categories:
+    type: category_list
+    default: ""
+  accepted_solution_topic_event_categories:
+    type: category_list
+    default: ""

--- a/plugin.rb
+++ b/plugin.rb
@@ -24,6 +24,11 @@ register_svg_icon "award"
 
 module ::DiscourseGamification
   PLUGIN_NAME = "discourse-gamification"
+
+  def self.category_allowed?(category_id, category_list)
+    list = category_list.to_s.split("|").map(&:to_i)
+    list.empty? || list.include?(category_id)
+  end
 end
 
 require_relative "lib/discourse_gamification/engine"
@@ -183,35 +188,48 @@ after_initialize do
 
   on(:post_created) do |post, opts, user|
     next if post.post_type != Post.types[:regular]
-    if post.post_number == 1
-      next if post.hidden? || post.wiki || post.deleted_at
-
-      DiscourseGamification::GamificationScoreEvent.record!(
-        user_id: user.id,
-        date: post.created_at.to_date,
-        points: SiteSetting.topic_created_score_value,
-        reason: "topic_created",
-      )
-      next
-    end
     next if post.hidden? || post.wiki || post.deleted_at
 
-    if SiteSetting.score_first_reply_of_day_enabled
-      already_exists = DiscourseGamification::GamificationScoreEvent.exists?(
-        user_id: user.id,
-        date: post.created_at.to_date,
-        reason: "daily_first_reply"
-      )
+    category_id = post.topic.category_id
 
-      if !already_exists
+    if post.post_number == 1
+      if DiscourseGamification::TopicCreated.enabled? &&
+           DiscourseGamification.category_allowed?(category_id, SiteSetting.post_created_event_categories)
         DiscourseGamification::GamificationScoreEvent.record!(
           user_id: user.id,
           date: post.created_at.to_date,
-          points: SiteSetting.first_reply_of_day_score_value,
-          reason: "daily_first_reply",
-          description: "하루 최초 댓글"
+          points: SiteSetting.topic_created_score_value,
+          reason: "topic_created",
         )
       end
+    else
+      if SiteSetting.score_first_reply_of_day_enabled
+        already_exists = DiscourseGamification::GamificationScoreEvent.exists?(
+          user_id: user.id,
+          date: post.created_at.to_date,
+          reason: "daily_first_reply"
+        )
+
+        if !already_exists
+          DiscourseGamification::GamificationScoreEvent.record!(
+            user_id: user.id,
+            date: post.created_at.to_date,
+            points: SiteSetting.first_reply_of_day_score_value,
+            reason: "daily_first_reply",
+            description: "하루 최초 댓글"
+          )
+        end
+      end
+    end
+
+    if DiscourseGamification::PostCreated.enabled? &&
+         DiscourseGamification.category_allowed?(category_id, SiteSetting.post_created_event_categories)
+      DiscourseGamification::GamificationScoreEvent.record!(
+        user_id: user.id,
+        date: post.created_at.to_date,
+        points: SiteSetting.post_created_score_value,
+        reason: "post_created",
+      )
     end
   end
   
@@ -261,7 +279,10 @@ after_initialize do
   end
 
   on(:accepted_solution) do |post|
-    if DiscourseGamification::Solutions.enabled?
+    category_id = post.topic.category_id
+
+    if DiscourseGamification::Solutions.enabled? &&
+         DiscourseGamification.category_allowed?(category_id, SiteSetting.accepted_solution_event_categories)
       DiscourseGamification::GamificationScoreEvent.record!(
         user_id: post.user_id,
         date: Time.zone.now.to_date,
@@ -270,7 +291,8 @@ after_initialize do
       )
     end
 
-    if DiscourseGamification::SolutionTopic.enabled?
+    if DiscourseGamification::SolutionTopic.enabled? &&
+         DiscourseGamification.category_allowed?(category_id, SiteSetting.accepted_solution_topic_event_categories)
       DiscourseGamification::GamificationScoreEvent.record!(
         user_id: post.topic.user_id,
         date: Time.zone.now.to_date,
@@ -281,7 +303,10 @@ after_initialize do
   end
 
   on(:unaccepted_solution) do |post|
-    if DiscourseGamification::Solutions.enabled?
+    category_id = post.topic.category_id
+
+    if DiscourseGamification::Solutions.enabled? &&
+         DiscourseGamification.category_allowed?(category_id, SiteSetting.accepted_solution_event_categories)
       DiscourseGamification::GamificationScoreEvent.record!(
         user_id: post.user_id,
         date: Time.zone.now.to_date,
@@ -290,7 +315,8 @@ after_initialize do
       )
     end
 
-    if DiscourseGamification::SolutionTopic.enabled?
+    if DiscourseGamification::SolutionTopic.enabled? &&
+         DiscourseGamification.category_allowed?(category_id, SiteSetting.accepted_solution_topic_event_categories)
       DiscourseGamification::GamificationScoreEvent.record!(
         user_id: post.topic.user_id,
         date: Time.zone.now.to_date,


### PR DESCRIPTION
## Summary
- add helper to check allowed categories
- record post creation and solution events immediately
- allow filtering instant events by category
- translate new settings to English and Korean
- add heading for instant event category filters

## Testing
- `bundle exec rake db:migrate` *(fails: Could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_686720539b58832c81dd1a6bc6b65042