### PR TITLE
Add Korean descriptions for score events

### DIFF
--- a/app/controllers/discourse_gamification/check_ins_controller.rb
+++ b/app/controllers/discourse_gamification/check_ins_controller.rb
@@ -12,11 +12,13 @@ class DiscourseGamification::CheckInsController < ApplicationController
 
     today = Date.current
     reason = SiteSetting.day_visited_score_reason
-    points = if today.saturday? || today.sunday?
+    weekend = today.saturday? || today.sunday?
+    points = if weekend
       SiteSetting.day_visited_weekend_score_value
     else
       SiteSetting.day_visited_score_value
     end
+    description = weekend ? "주말출석" : "출석"
 
     existing = DiscourseGamification::GamificationScoreEvent.find_by(
       user_id: current_user.id,
@@ -32,6 +34,7 @@ class DiscourseGamification::CheckInsController < ApplicationController
         date: today,
         points: points,
         reason: reason,
+        description: description,
       )
 
       render json: { points_awarded: true, points: event.points }

--- a/plugin.rb
+++ b/plugin.rb
@@ -217,6 +217,7 @@ after_initialize do
           date: post.created_at.to_date,
           points: SiteSetting.topic_created_score_value,
           reason: "topic_created",
+          description: "게시물게시",
         )
       end
     else
@@ -233,7 +234,7 @@ after_initialize do
             date: post.created_at.to_date,
             points: SiteSetting.first_reply_of_day_score_value,
             reason: "daily_first_reply",
-            description: "하루 최초 댓글"
+            description: "댓글"
           )
         end
       end
@@ -247,6 +248,7 @@ after_initialize do
         date: post.created_at.to_date,
         points: SiteSetting.post_created_event_score_value,
         reason: "post_created",
+        description: "게시물게시",
       )
     end
   end


### PR DESCRIPTION
## Summary
- record check-in events with Korean descriptions
- add Korean descriptions for topic, post, and reply score events

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rake` *(fails: could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_6868a03cbab4832c8987104f6f7ca34c