### PR TITLE
Adjust first login reward logic

### DIFF
--- a/lib/discourse_gamification/first_login_rewarder.rb
+++ b/lib/discourse_gamification/first_login_rewarder.rb
@@ -1,6 +1,5 @@
 module DiscourseGamification
   class FirstLoginRewarder
-    POINTS = 10
     DESCRIPTION = "first_login"
 
     def initialize(user)
@@ -14,10 +13,17 @@ module DiscourseGamification
       today = Date.current
       return if GamificationScoreEvent.exists?(user_id: @user.id, date: today, description: DESCRIPTION)
 
+      weekend = today.saturday? || today.sunday?
+      points = if weekend
+        SiteSetting.day_visited_weekend_score_value
+      else
+        SiteSetting.day_visited_score_value
+      end
+
       GamificationScoreEvent.create!(
         user_id: @user.id,
         date: today,
-        points: POINTS,
+        points: points,
         description: DESCRIPTION,
         reason: DESCRIPTION,
       )

--- a/spec/services/first_login_rewarder_spec.rb
+++ b/spec/services/first_login_rewarder_spec.rb
@@ -7,16 +7,34 @@ RSpec.describe DiscourseGamification::FirstLoginRewarder do
 
   before { SiteSetting.discourse_gamification_enabled = true }
 
-  it 'creates event and updates score only once per day' do
-    freeze_time Date.today
-    described_class.new(user).call
+  it 'uses day visited score values and records only once per day' do
+    SiteSetting.score_day_visited_enabled = false
+    SiteSetting.day_visited_score_value = 5
+    SiteSetting.day_visited_weekend_score_value = 10
 
-    event = DiscourseGamification::GamificationScoreEvent.find_by(user_id: user.id, description: 'first_login')
-    expect(event).to be_present
-    expect(DiscourseGamification::GamificationScore.find_by(user_id: user.id).score).to eq(10)
+    freeze_time Date.parse('2022-01-03') do
+      described_class.new(user).call
 
-    described_class.new(user).call
-    expect(DiscourseGamification::GamificationScoreEvent.where(user_id: user.id, description: 'first_login').count).to eq(1)
-    expect(DiscourseGamification::GamificationScore.find_by(user_id: user.id).score).to eq(10)
+      event = DiscourseGamification::GamificationScoreEvent.find_by(user_id: user.id, description: 'first_login')
+      expect(event).to be_present
+      expect(event.points).to eq(5)
+      expect(DiscourseGamification::GamificationScore.find_by(user_id: user.id).score).to eq(5)
+
+      described_class.new(user).call
+      expect(DiscourseGamification::GamificationScoreEvent.where(user_id: user.id, description: 'first_login').count).to eq(1)
+      expect(DiscourseGamification::GamificationScore.find_by(user_id: user.id).score).to eq(5)
+    end
+  end
+
+  it 'uses weekend score value on weekends' do
+    SiteSetting.score_day_visited_enabled = false
+    SiteSetting.day_visited_score_value = 5
+    SiteSetting.day_visited_weekend_score_value = 10
+
+    freeze_time Date.parse('2022-01-01') do
+      described_class.new(user).call
+      event = DiscourseGamification::GamificationScoreEvent.find_by(user_id: user.id, description: 'first_login')
+      expect(event.points).to eq(10)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- award day visited points for first login
- test weekday and weekend login scenarios

## Testing
- `bundle exec rake db:migrate:status` *(fails: Could not find rubocop-discourse-3.12.1, syntax_tree-6.2.0, ...)*
- `bundle exec rspec spec/services/first_login_rewarder_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_6868ae4ea87c832c92ec4018f6d7a12d