### PR TITLE
Fix gamification level for all users

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -151,10 +151,10 @@ after_initialize do
     end
   end
     
-  # # 🎯 출력 대상으로 명시적으로 추가
-  # add_to_serializer(:basic_user, :attributes) do
-  #   (defined?(super) ? Array(super) : []) + [:gamification_level_info]
-  # end
+  # 🎯 basic_user serializer에 속성 목록을 명시적으로 추가한다
+  add_to_serializer(:basic_user, :attributes) do
+    (defined?(super) ? Array(super) : []) + [:gamification_level_info]
+  end
   
 
   # 2. 현재 로그인한 사용자 serializer 확장


### PR DESCRIPTION
## Summary
- ensure `gamification_level_info` attribute is emitted from `BasicUserSerializer`

## Testing
- `bundle exec rake db:migrate` *(fails: missing gems)*
- `pnpm --version` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868e0c5f73c832cb47dddd6e7eb5f86