### PR TITLE
Add related fields to score events

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ Default score settings include:
 
 Set any of these values to `0` to disable scoring for that action. Changes take
 effect immediately for new events.
+
+### Gamification Score Events
+
+The `gamification_score_events` table stores the history of points awarded. Important columns include:
+- `user_id` and `date` of the event
+- `points` amount and `reason`
+- optional `description`
+- `related_id` identifies the topic, reply or other entity linked to the event
+- `related_type` describes the entity type such as `topic`, `reply` or `user`
+

--- a/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
+++ b/app/controllers/discourse_gamification/admin_gamification_score_event_controller.rb
@@ -18,7 +18,7 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
 
   def create
     params.require(%i[user_id date points reason])
-    params.permit(:description)
+    params.permit(:description, :related_id, :related_type)
 
     event = DiscourseGamification::GamificationScoreEvent.record!(
       user_id: params[:user_id],
@@ -26,6 +26,8 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
       points: params[:points],
       reason: params[:reason],
       description: params[:description],
+      related_id: params[:related_id],
+      related_type: params[:related_type],
     )
 
     render_serialized(event, AdminGamificationScoreEventSerializer, root: false)
@@ -33,12 +35,16 @@ class DiscourseGamification::AdminGamificationScoreEventController < Admin::Admi
 
   def update
     params.require(%i[id points reason])
-    params.permit(:description)
+    params.permit(:description, :related_id, :related_type)
 
     event = DiscourseGamification::GamificationScoreEvent.find(params[:id])
     raise Discourse::NotFound unless event
 
-    if event.update(points: params[:points], reason: params[:reason], description: params[:description] || event.description)
+    if event.update(points: params[:points],
+                    reason: params[:reason],
+                    description: params[:description] || event.description,
+                    related_id: params[:related_id],
+                    related_type: params[:related_type])
       render json: success_json
     else
       render_json_error(event)

--- a/app/models/discourse_gamification/gamification_score_event.rb
+++ b/app/models/discourse_gamification/gamification_score_event.rb
@@ -12,8 +12,16 @@ module ::DiscourseGamification
 
     validates :reason, presence: true
 
-    def self.record!(user_id:, points:, date: Date.today, reason:, description: nil)
-      create!(user_id: user_id, points: points, date: date, reason: reason, description: description)
+    def self.record!(user_id:, points:, date: Date.today, reason:, description: nil, related_id: nil, related_type: nil)
+      create!(
+        user_id: user_id,
+        points: points,
+        date: date,
+        reason: reason,
+        description: description,
+        related_id: related_id,
+        related_type: related_type,
+      )
     end
 
     private
@@ -45,6 +53,8 @@ end
 #  points      :integer          not null
 #  description :text
 #  reason      :string           default("")
+#  related_id  :text
+#  related_type: text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/serializers/admin_gamification_score_event_serializer.rb
+++ b/app/serializers/admin_gamification_score_event_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AdminGamificationScoreEventSerializer < ApplicationSerializer
-  attributes :id, :user_id, :date, :points, :reason, :description, :created_at, :updated_at
+  attributes :id, :user_id, :date, :points, :reason, :description, :related_id, :related_type, :created_at, :updated_at
 end

--- a/db/migrate/20250701000000_add_related_fields_to_gamification_score_events.rb
+++ b/db/migrate/20250701000000_add_related_fields_to_gamification_score_events.rb
@@ -1,0 +1,6 @@
+class AddRelatedFieldsToGamificationScoreEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :gamification_score_events, :related_id, :text
+    add_column :gamification_score_events, :related_type, :text
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -237,6 +237,8 @@ after_initialize do
           points: SiteSetting.topic_created_score_value,
           reason: "topic_created",
           description: "게시물게시",
+          related_id: post.topic_id,
+          related_type: "topic",
         )
       end
     else
@@ -253,7 +255,9 @@ after_initialize do
             date: post.created_at.to_date,
             points: SiteSetting.first_reply_of_day_score_value,
             reason: "daily_first_reply",
-            description: "댓글"
+            description: "댓글",
+            related_id: post.id,
+            related_type: "reply"
           )
         end
       end
@@ -268,6 +272,8 @@ after_initialize do
         points: SiteSetting.post_created_event_score_value,
         reason: "post_created",
         description: "게시물게시",
+        related_id: post.topic_id,
+        related_type: "topic",
       )
     end
   end
@@ -327,6 +333,9 @@ after_initialize do
         date: Time.zone.now.to_date,
         points: SiteSetting.accepted_solution_event_score_value,
         reason: "accepted_solution",
+        description: "accepted_solution",
+        related_id: post.topic_id,
+        related_type: "topic",
       )
     end
 
@@ -351,6 +360,9 @@ after_initialize do
         date: Time.zone.now.to_date,
         points: -SiteSetting.accepted_solution_event_score_value,
         reason: "accepted_solution_removed",
+        description: "accepted_solution_removed",
+        related_id: post.topic_id,
+        related_type: "topic",
       )
     end
 


### PR DESCRIPTION
## Summary
- add `related_id` and `related_type` columns for score events
- expose new fields in API serializers and controllers
- store descriptions for accepted solution events
- record related objects when scoring topics or replies
- document score event fields in README

## Testing
- `bundle exec rake` *(fails: Could not find rubocop-discourse-3.12.1, syntax_tree-6.2.0, activesupport-8.0.2...)*

------
https://chatgpt.com/codex/tasks/task_e_6870a8edf0f4832ca701003215a65f2b